### PR TITLE
Enable GPUEnabler to work with Scala 2.11

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <groupId>com.ibm</groupId>
-  <artifactId>gpu-enabler-examples_2.10</artifactId>
+  <artifactId>gpu-enabler-examples_${scala.binary.version}</artifactId>
   <version>1.0.0</version>
   <inceptionYear>2016</inceptionYear>
   <packaging>jar</packaging>
@@ -54,7 +54,7 @@
   <dependencies>
     <dependency>
       <groupId>com.ibm</groupId>
-      <artifactId>gpu-enabler_2.10</artifactId>
+      <artifactId>gpu-enabler_${scala.binary.version}</artifactId>
       <version>1.0.0</version>
     </dependency>
     <!--dependency>

--- a/gpu-enabler/dependency-reduced-pom.xml
+++ b/gpu-enabler/dependency-reduced-pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.ibm</groupId>
-  <artifactId>gpu-enabler_2.10</artifactId>
+  <artifactId>gpu-enabler_2.11</artifactId>
   <version>1.0.0</version>
   <inceptionYear>2016</inceptionYear>
   <build>
@@ -289,7 +289,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.10.5</version>
+      <version>2.11.7</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -324,8 +324,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
-      <version>1.6.1</version>
+      <artifactId>spark-core_2.11</artifactId>
+      <version>2.0.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -344,12 +344,12 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
-      <version>2.2.5</version>
+      <artifactId>scalatest_2.11</artifactId>
+      <version>2.2.6</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <artifactId>scala-xml_2.10</artifactId>
+          <artifactId>scala-xml_2.11</artifactId>
           <groupId>org.scala-lang.modules</groupId>
         </exclusion>
       </exclusions>

--- a/gpu-enabler/dependency-reduced-pom.xml
+++ b/gpu-enabler/dependency-reduced-pom.xml
@@ -343,6 +343,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-xml</artifactId>
+      <version>2.11.0-M4</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.11</artifactId>
       <version>2.2.6</version>

--- a/gpu-enabler/pom.xml
+++ b/gpu-enabler/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <groupId>com.ibm</groupId>
-  <artifactId>gpu-enabler_2.10</artifactId>
+  <artifactId>gpu-enabler_${scala.binary.version}</artifactId>
   <version>1.0.0</version>
   <inceptionYear>2016</inceptionYear>
   <packaging>jar</packaging>

--- a/gpu-enabler/src/main/scala/com/ibm/gpuenabler/ColumnPartitionSchema.scala
+++ b/gpu-enabler/src/main/scala/com/ibm/gpuenabler/ColumnPartitionSchema.scala
@@ -259,8 +259,8 @@ private[gpuenabler] class ColumnSchema(
       in.readObject().asInstanceOf[Vector[(String, String)]].map { case (clsName, propName) =>
         val cls = CUDAUtils.sparkUtils.classForName(clsName)
         val typeSig = mirror.classSymbol(cls).typeSignature
-        typeSig.declaration(universe.stringToTermName(propName)).asTerm
-        // typeSig.decl(universe.TermName(propName)).asTerm // Scala_2.11
+        typeSig.decl(universe.TermName(propName)).asTerm
+        // typeSig.declaration(universe.stringToTermName(propName)).asTerm // Scala_2.10
       }
   }
 

--- a/gpu-enabler/src/main/scala/org/apache/spark/gpuenabler/CUDAUtils.scala
+++ b/gpu-enabler/src/main/scala/org/apache/spark/gpuenabler/CUDAUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark.gpuenabler
 import org.apache.spark.util.Utils
 import org.apache.spark.rpc.{RpcCallContext, RpcEndpointRef, RpcEnv, ThreadSafeRpcEndpoint}
 import org.apache.spark.util.RpcUtils
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import org.apache.spark.rpc.RpcEndpoint
 import org.apache.spark.{SparkEnv, SparkContext}
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
         <scope>test</scope>
     </dependency>
     <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-xml</artifactId>
+        <version>2.11.0-M4</version>
+    </dependency>
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
       <version>2.2.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
   <inceptionYear>2016</inceptionYear>
   <packaging>pom</packaging>
   <properties>
-    <scala.version>2.10.5</scala.version>
-    <scala.binary.version>2.10</scala.binary.version>
+    <scala.version>2.11.7</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <PermGen>64m</PermGen>
@@ -65,8 +65,8 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.10</artifactId>
-      <version>1.6.1</version>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>2.0.0</version>
         <exclusions>
             <exclusion>
                 <!-- make sure wrong scala version is not pulled in -->
@@ -100,14 +100,14 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
-      <version>2.2.5</version>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <version>2.2.6</version>
       <scope>test</scope>
         <exclusions>
             <exclusion>
                 <!-- make sure wrong scala version is not pulled in -->
                 <groupId>org.scala-lang.modules</groupId>
-                <artifactId>scala-xml_2.10</artifactId>
+                <artifactId>scala-xml_${scala.binary.version}</artifactId>
             </exclusion>
         </exclusions>
 


### PR DESCRIPTION
Address issue #23 .

After reviewing, kindly squash and merge the code changes so that the 2 commits will be combined as one.
Thanks,
Joe.
