### PR TITLE
Support for Heterogeneous environment

### DIFF
--- a/gpu-enabler/src/main/scala/com/ibm/gpuenabler/CUDAManager.scala
+++ b/gpu-enabler/src/main/scala/com/ibm/gpuenabler/CUDAManager.scala
@@ -17,8 +17,9 @@
 
 package com.ibm.gpuenabler
 
+import java.util.Date
 import java.net.URL
-
+import java.util.concurrent.ConcurrentHashMap
 import jcuda.Pointer
 import jcuda.driver.JCudaDriver._
 import jcuda.driver.{CUdeviceptr, CUmodule, JCudaDriver}
@@ -26,11 +27,21 @@ import jcuda.runtime.JCuda
 import org.apache.commons.io.IOUtils
 import org.apache.spark.SparkException
 import org.slf4j.{Logger, LoggerFactory}
-
+import java.lang.management.ManagementFactory
 import scala.collection.mutable.HashMap
+import scala.collection.mutable
+import java.text.SimpleDateFormat
+
+/*
+private[gpuenabler] object CUDAManagerCachedModule {
+  private val cachedModules = new ConcurrentHashMap[(String, Int), CUmodule]
+  def getInstance() : ConcurrentHashMap[(String, Int), CUmodule] = { cachedModules }
+}
+*/
 
 private[gpuenabler] object CUDAManagerCachedModule {
-  private val cachedModules = new HashMap[(String, Int), CUmodule]
+//  val lock:Object = new Object
+  private val cachedModules = new HashMap[(String, Int), CUmodule] 
   def getInstance() : HashMap[(String, Int), CUmodule] = { cachedModules }
 }
 
@@ -38,19 +49,44 @@ private[gpuenabler] class CUDAManager {
   // Initialization
   // This is supposed to be called before ANY other JCuda* call to ensure we have properly loaded
   // native jCuda library and cuda context
+<<<<<<< HEAD
   try {
     JCudaDriver.setExceptionsEnabled(true)
     JCudaDriver.cuInit(0)
+=======
+  val executorId = SparkEnv.get.executorId  match {
+    case "driver" => 0
+    case _ => SparkEnv.get.executorId.toInt
+  }
+  val dateFormatter = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss.SSS")
+
+  var isGPUEnabled = false
+
+  try {
+    JCudaDriver.setExceptionsEnabled(true)
+    JCudaDriver.cuInit(0)
+    isGPUEnabled = true
+>>>>>>> 1826bb2... handle nodes with no GPU attached
   } catch {
+    case ex: UnsatisfiedLinkError => println("Native CUDA libraries not detected.")
+    case ex: NoClassDefFoundError => println("Native CUDA libraries not detected.")
+/*
     case ex: UnsatisfiedLinkError =>
       throw new SparkException("Could not initialize CUDA, because native jCuda libraries were " +
         "not detected - make sure Driver and Executors are able to load them", ex)
     case ex: NoClassDefFoundError =>
       throw new SparkException("Could not initialize CUDA, because native jCuda libraries were " +
         "not detected - make sure Driver and Executors are able to load them", ex)
+*/
 
     case ex: Throwable =>
       throw new SparkException("Could not initialize CUDA because of unknown reason", ex)
+  }
+
+  def gpuCount = {
+    val count = new Array[Int](1)
+    cuDeviceGetCount(count)
+    count(0)
   }
 
   // private[gpuenabler] def cachedLoadModule(resource: Either[URL, (String, String)]): CUmodule = {
@@ -71,14 +107,22 @@ private[gpuenabler] class CUDAManager {
 
     val devIx = new Array[Int](1)
     JCuda.cudaGetDevice(devIx)
+<<<<<<< HEAD
+=======
+
+>>>>>>> 1826bb2... handle nodes with no GPU attached
     synchronized {
       // Since multiple modules cannot be loaded into one context in runtime API,
       //   we use singleton cache http://stackoverflow.com/questions/32502375/
       //   loading-multiple-modules-in-jcuda-is-not-working
       // TODO support loading multiple ptxs
       //   http://stackoverflow.com/questions/32535828/jit-in-jcuda-loading-multiple-ptx-modules
+
       CUDAManagerCachedModule.getInstance.getOrElseUpdate((key, devIx(0)), {
+<<<<<<< HEAD
     // println(" MODULE LOAD ")
+=======
+>>>>>>> 1826bb2... handle nodes with no GPU attached
         // TODO maybe unload the module if it won't be needed later
         var moduleBinaryData: Array[Byte] = null
         if (resourceURL != null) {
@@ -94,6 +138,7 @@ private[gpuenabler] class CUDAManager {
         moduleBinaryData0(moduleBinaryData.length) = 0
         val module = new CUmodule
         JCudaDriver.cuModuleLoadData(module, moduleBinaryData0)
+	CUDAManagerCachedModule.getInstance.put((key, devIx(0)), module)
         module
       })
     }

--- a/gpu-enabler/src/test/resources/Makefile
+++ b/gpu-enabler/src/test/resources/Makefile
@@ -1,0 +1,15 @@
+CUDA_PATH ?= /usr
+CXX ?= g++
+NVCC ?= $(CUDA_PATH)/bin/nvcc
+COMPUTE_CAPABILITY ?= 35
+CXXFLAGS ?= -m64 -O3 -Xcompiler -Wall --std=c++11 -g
+NVCCFLAGS ?= -arch=sm_$(COMPUTE_CAPABILITY) -Xptxas="-v"
+
+
+all : testCUDAKernels.ptx
+
+testCUDAKernels.ptx: testCUDAKernels.cu
+	$(NVCC) -ccbin $(CXX) $(CXXFLAGS) $(NVCCFLAGS) -ptx -o $@ -c $^
+
+clean:
+	rm -f testCUDAKernels.ptx


### PR DESCRIPTION
This enhancement enables GPUEnabler plugin to recognize the environment it runs(feature #5). The environment can be any one of the following,
1. Single GPU attached to the node.
2. Multiple GPUs attached to the node.
3. Multiple GPUs spread across the Spark cluster.
4. Spark Cluster with nodes with GPU attached and w/o GPUs.

By default, all the spark jobs submitted in local mode will use GPU device 0, if GPU is attached to the node.

If the spark job is submitted to a Scheduler, then the executor will choose the GPU device based on the executor ID assigned to it by the scheduler. For example, in a node with 4 GPUs attached, a submitted spark job which demands 4 executors to complete its task will spawn executors each assigned to individual GPUs and will run the task to completion. If 8 executors are demanded by a Spark job, each GPU will be assigned to 2 executors and they will used in parallel. 

To submit a job to a spark cluster make sure the GPUEnabler jar is placed in all the nodes and
the file `${SPARK_HOME}/conf/spark-defaults.conf` in respective nodes contains the location of the jar as part of the config parameter `spark.executor.extraClassPath` as follows,

```
 spark.executor.extraClassPath    /home/joe/GPUEnabler/gpu-enabler/target/gpu-enabler_2.11-1.0.0.jar
```

Then `spark-submit` can be used to submit the job as follows,

```
~/spark/bin/spark-submit 
      --executor-cores=4 
      --total-executor-cores 60 
      --executor-memory=6g 
      --class com.ibm.gpuenabler.SparkGPULR 
      --jars  ~/GPUEnabler/gpu-enabler/target/gpu-enabler_2.11-1.0.0.jar  
      ~/GPUEnabler/examples/target/gpu-enabler-examples_2.11-1.0.0.jar spark://soe15:7077 60 1000000 400 5
```
**Note:**
Make sure to give sufficient memory to executors when dealing with huge datasets to avoid Out of Memory errors.

