### PR TITLE
patch for perfDebug sample prog

### DIFF
--- a/examples/src/main/resources/GpuEnablerExamples.cu
+++ b/examples/src/main/resources/GpuEnablerExamples.cu
@@ -156,3 +156,13 @@ __global__ void multiplyBy2o(int *size, const long *in, long *out) {
     }
 }
 
+extern "C"
+// dummy kernel used to load the data to GPU
+__global__ void load(int size, const long *in) {
+    const int ix = threadIdx.x + blockIdx.x * blockDim.x;
+
+    if (ix < size) {
+    }
+}
+
+

--- a/examples/src/main/resources/GpuEnablerExamples.ptx
+++ b/examples/src/main/resources/GpuEnablerExamples.ptx
@@ -728,4 +728,16 @@ BB8_2:
 	ret;
 }
 
+	// .globl	load
+.visible .entry load(
+	.param .u32 load_param_0,
+	.param .u64 load_param_1
+)
+{
+
+
+
+	ret;
+}
+
 


### PR DESCRIPTION
Patch for issue #52 
The reason for inconsistent output from the sample program "perfDebug" is, the GPU kernel updates the input parameter values which are cached and this cached data is used later for other calculation which results in inconsistency. 

