### PR TITLE
Performance optimization on speed and memory

### DIFF
--- a/examples/src/main/scala/com/ibm/gpuenabler/perfDebug.scala
+++ b/examples/src/main/scala/com/ibm/gpuenabler/perfDebug.scala
@@ -113,12 +113,6 @@ object perfDebug {
       println("Output is " + output)
     })
 
-    timeit("DS: Only Datapoint cached", {
-      val mapDS11 = data111.mapExtFunc(2 * _, dsmapFunction) 
-      val output = mapDS11.reduceExtFunc(_ + _, dsreduceFunction)
-      println("Output is " + output)
-    })
-    
     timeit("DS: CPU", {
       val output = data.map(2 * _).reduce(_ + _)
       println("Output is " + output)

--- a/examples/src/main/scala/com/ibm/gpuenabler/perfDebug.scala
+++ b/examples/src/main/scala/com/ibm/gpuenabler/perfDebug.scala
@@ -81,7 +81,7 @@ object perfDebug {
     val rd = spark.range(1, n+1, 1, part).cache()
     rd.count()
 
-    val data = rd.cacheGpu()
+    val data = rd.cacheGpu(true)
     // Load the data to GPU
     data.loadGpu()
 

--- a/gpu-enabler/dependency-reduced-pom.xml
+++ b/gpu-enabler/dependency-reduced-pom.xml
@@ -90,7 +90,7 @@
           <junitxml>.</junitxml>
           <forkMode>once</forkMode>
           <filereports>WDF TestSuite.txt</filereports>
-          <argLine>-Djava.library.path=${project.build.directory}/lib/ -Xms42g -Xmx45G -Xmn40G</argLine>
+          <argLine>-Djava.library.path=${project.build.directory}/lib/ -Xms12g -Xmx25G -Xmn10G</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/gpu-enabler/pom.xml
+++ b/gpu-enabler/pom.xml
@@ -238,7 +238,7 @@
             <junitxml>.</junitxml>
             <forkMode>once</forkMode>
             <filereports>WDF TestSuite.txt</filereports>
-            <argLine>-Djava.library.path=${project.build.directory}/lib/ -Xms42g -Xmx45G -Xmn40G</argLine>
+            <argLine>-Djava.library.path=${project.build.directory}/lib/ -Xms52g -Xmx55G -Xmn50G</argLine>
           </configuration>
           <executions>
             <execution>

--- a/gpu-enabler/pom.xml
+++ b/gpu-enabler/pom.xml
@@ -238,7 +238,7 @@
             <junitxml>.</junitxml>
             <forkMode>once</forkMode>
             <filereports>WDF TestSuite.txt</filereports>
-            <argLine>-Djava.library.path=${project.build.directory}/lib/ -Xms52g -Xmx55G -Xmn50G</argLine>
+            <argLine>-Djava.library.path=${project.build.directory}/lib/ -Xms12g -Xmx25G -Xmn10G</argLine>
           </configuration>
           <executions>
             <execution>

--- a/gpu-enabler/src/main/scala/com/ibm/gpuenabler/CUDADSUtils.scala
+++ b/gpu-enabler/src/main/scala/com/ibm/gpuenabler/CUDADSUtils.scala
@@ -167,7 +167,7 @@ case class MAPGPUExec[T, U](cf: DSCUDAFunction, constArgs : Array[Any],
 
         override def next: InternalRow =
           InternalRow(outEnc
-             .fromRow(jcudaIterator.next().copy()))
+             .fromRow(jcudaIterator.next()))
       }
     }
   }

--- a/gpu-enabler/src/main/scala/com/ibm/gpuenabler/CUDADSUtils.scala
+++ b/gpu-enabler/src/main/scala/com/ibm/gpuenabler/CUDADSUtils.scala
@@ -159,6 +159,8 @@ case class MAPGPUExec[T, U](cf: DSCUDAFunction, constArgs : Array[Any],
       // Triggers execution
       jcudaIterator.hasNext()
 
+      list.clear()
+
       val outEnc = outexprEnc
         .resolveAndBind(getAttributes(outputEncoder.schema))
 

--- a/gpu-enabler/src/main/scala/com/ibm/gpuenabler/ColumnPartitionSchema.scala
+++ b/gpu-enabler/src/main/scala/com/ibm/gpuenabler/ColumnPartitionSchema.scala
@@ -259,8 +259,8 @@ private[gpuenabler] class ColumnSchema(
       in.readObject().asInstanceOf[Vector[(String, String)]].map { case (clsName, propName) =>
         val cls = CUDAUtils.sparkUtils.classForName(clsName)
         val typeSig = mirror.classSymbol(cls).typeSignature
-        typeSig.declaration(universe.stringToTermName(propName)).asTerm
-        // typeSig.decl(universe.TermName(propName)).asTerm // Scala_2.11
+        // typeSig.declaration(universe.stringToTermName(propName)).asTerm // Scala_2.10
+        typeSig.decl(universe.TermName(propName)).asTerm // Scala_2.11
       }
   }
 

--- a/gpu-enabler/src/main/scala/com/ibm/gpuenabler/GPUSparkEnv.scala
+++ b/gpu-enabler/src/main/scala/com/ibm/gpuenabler/GPUSparkEnv.scala
@@ -51,6 +51,7 @@ private[gpuenabler] class GPUSparkEnv() {
                     isLocal)
   val isGPUEnabled = if (_cudaManager != null) _cudaManager.isGPUEnabled else false
   def gpuCount = if (isGPUEnabled) _cudaManager.gpuCount else 0
+
   val isGPUCodeGenEnabled =
     isGPUEnabled && SparkEnv.get.conf.getBoolean("spark.gpu.codegen", false)
 
@@ -77,6 +78,10 @@ private[gpuenabler] object GPUSparkEnv {
   def initalize(): Unit = {
       env = new GPUSparkEnv()
   }
+
+  // Auto Caching in GPU Enabled by default
+  val isAutoCacheEnabled: Boolean =
+    if (SparkEnv.get.conf.getInt("spark.gpuenabler.autocache", 1) == 1) true else false
  
   def get = {
       val curSparkEnv = SparkEnv.get

--- a/gpu-enabler/src/main/scala/com/ibm/gpuenabler/JCUDACodeGen.scala
+++ b/gpu-enabler/src/main/scala/com/ibm/gpuenabler/JCUDACodeGen.scala
@@ -679,7 +679,8 @@ object JCUDACodeGen extends _Logging {
         |           int blockID, int[] userGridSizes, int[] userBlockSizes, int stages) {
         |        inpitr = inp;
         |        numElements = size;
-        |        hasNextLoop = ${cf.outputSize.getOrElse("numElements")};
+        |        if (!((cached & 4) > 0)) hasNextLoop = ${cf.outputSize.getOrElse("numElements")};
+        |        else hasNextLoop = 1;
         |
         |        refs = inprefs;
         |

--- a/gpu-enabler/src/test/scala/com/ibm/gpuenabler/CUDADSFunctionSuite.scala
+++ b/gpu-enabler/src/test/scala/com/ibm/gpuenabler/CUDADSFunctionSuite.scala
@@ -533,7 +533,7 @@ class CUDADSFunctionSuite extends FunSuite {
       try {
         val data = spark.range(1, n+1, 1, 16).cache()
         data.count()
-        val mapDS = data.mapExtFunc(2 * _, mapFunction).cacheGpu()
+        val mapDS = data.mapExtFunc(2 * _, mapFunction).cacheGpu(true)
         val output: Long = mapDS.reduceExtFunc(_ + _, reduceFunction)
         mapDS.unCacheGpu()
         assert(output == n * (n + 1))

--- a/gpu-enabler/src/test/scala/com/ibm/gpuenabler/CUDADSFunctionSuite.scala
+++ b/gpu-enabler/src/test/scala/com/ibm/gpuenabler/CUDADSFunctionSuite.scala
@@ -531,9 +531,9 @@ class CUDADSFunctionSuite extends FunSuite {
 
       val n: Long = 100000000L
       try {
-        val data = spark.range(1, n+1, 1, 16).cache()
+        val data = spark.range(1, n+1, 1, 16).cache()//.cacheGpu(true)
         data.count()
-        val mapDS = data.mapExtFunc(2 * _, mapFunction).cacheGpu(true)
+        val mapDS = data.mapExtFunc(2 * _, mapFunction).cacheGpu()
         val output: Long = mapDS.reduceExtFunc(_ + _, reduceFunction)
         mapDS.unCacheGpu()
         assert(output == n * (n + 1))


### PR DESCRIPTION
This pull request will address issues reported in #58 and #54 .

**Performance Optimization:**

1. Optimize data transfers between CPU and GPU between multiple GPUEnabler APIs calls.
2. Handle automatic data cleanup once the job is completed.
3. Introduce GPU only cache so that it can be applicable between GPU APIs calls as the intermediary data is not required other than GPU operations. To invoke this type of cache,

> ds.cacheGpu(`onlyGPU`: true)

Note: By default, it will be turned off. So its left up to the application developer to use appropriately. 

**Fix for Memory Leak:**

1. The memory used by host to transfer data into GPU is left uncleaned even after the job is completed. So appropriate changes are made to trigger data cleanup.
2. After this change, the system memory consumption remains constant for every iteration.
