### PR TITLE
#Issue51: Support for Multi Dimension as input GPU Grid dimension

### DIFF
--- a/examples/src/main/scala/com/ibm/gpuenabler/GpuDSArrayMult.scala
+++ b/examples/src/main/scala/com/ibm/gpuenabler/GpuDSArrayMult.scala
@@ -53,16 +53,19 @@ object GpuDSArrayMult {
 
     // 2. Sample Reduce Operation - Sum of all elements in the array
     val dimensions = (size: Long, stage: Int) => stage match {
-      case 0 => (64, 256)
-      case 1 => (1, 1)
+      case 0 => (64, 256, 1, 1, 1, 1)
+      case 1 => (1, 1, 1, 1, 1, 1)
     }
+
+    val gpuParams = gpuParameters(dimensions)
+
     val sumFunc = DSCUDAFunction(
       "suml",
       Array("value"),
       Array("value"),
       ptxURL,
       Some((size: Long) => 2),
-      Some(dimensions), outputSize=Some(1))
+      Some(gpuParams), outputSize=Some(1))
 
     val results2 = dataPts
           .mapExtFunc(_ * 2, mulFunc)

--- a/examples/src/main/scala/com/ibm/gpuenabler/perfDebug.scala
+++ b/examples/src/main/scala/com/ibm/gpuenabler/perfDebug.scala
@@ -70,13 +70,20 @@ object perfDebug {
       Array("value"),
       ptxURL1)
 
+    val dimensions2 = (size: Long, stage: Int) => stage match {
+      case 0 => (64, 256, 1, 1, 1, 1)
+      case 1 => (1, 1, 1, 1, 1, 1)
+    }
+
+    val gpuParams = gpuParameters(dimensions2)
+
     val dsreduceFunction = DSCUDAFunction(
       "suml",
       Array("value"),
       Array("value"),
       ptxURL1,
       Some((size: Long) => 2),
-      Some(dimensions), outputSize=Some(1))
+      Some(gpuParams), outputSize=Some(1))
 
     val rd = spark.range(1, n+1, 1, part).cache()
     rd.count()

--- a/gpu-enabler/src/main/scala/com/ibm/gpuenabler/CUDAManager.scala
+++ b/gpu-enabler/src/main/scala/com/ibm/gpuenabler/CUDAManager.scala
@@ -100,10 +100,10 @@ private class CUDAManager {
         } else {
           moduleBinaryData = ptxString.getBytes()
         }
- 
-        val moduleBinaryData0 = new Array[Byte](moduleBinaryData.length + 1)
-        System.arraycopy(moduleBinaryData, 0, moduleBinaryData0, 0, moduleBinaryData.length)
-        moduleBinaryData0(moduleBinaryData.length) = 0
+        val moduleBinaryDataLength = moduleBinaryData.length
+        val moduleBinaryData0 = new Array[Byte](moduleBinaryDataLength + 1)
+        System.arraycopy(moduleBinaryData, 0, moduleBinaryData0, 0, moduleBinaryDataLength)
+        moduleBinaryData0(moduleBinaryDataLength) = 0
         val module = new CUmodule
         JCudaDriver.cuModuleLoadData(module, moduleBinaryData0)
         module

--- a/gpu-enabler/src/main/scala/com/ibm/gpuenabler/CUDARDDUtils.scala
+++ b/gpu-enabler/src/main/scala/com/ibm/gpuenabler/CUDARDDUtils.scala
@@ -386,7 +386,7 @@ object CUDARDDImplicits {
       val reducePartition: (TaskContext, Iterator[T]) => Option[T] =
         (ctx: TaskContext, data: Iterator[T]) => {
           // Handle partitions with no data
-          if (data.length > 0) {
+          if (!(data.isEmpty)) {
             data match {
               case col: HybridIterator[T] =>
                 if (col.numElements != 0) {

--- a/gpu-enabler/src/main/scala/com/ibm/gpuenabler/JCUDACodegenIterator.scala
+++ b/gpu-enabler/src/main/scala/com/ibm/gpuenabler/JCUDACodegenIterator.scala
@@ -28,6 +28,6 @@ abstract class JCUDACodegenIterator extends Iterator[InternalRow] {
   def next() : InternalRow
   def init(itr : java.util.Iterator[InternalRow], args: Array[Any],size : Int,
            cached: Int, gpuPtrs: java.util.List[java.util.Map[String, CUdeviceptr]], blockID: Int,
-           userGridSizes: Array[Int], userBlockSizes: Array[Int], stages: Int)
+           userGridSizes: Array[Array[Int]], userBlockSizes: Array[Array[Int]], stages: Int, smSize: Int)
 }
 

--- a/gpu-enabler/src/test/resources/testDSCUDAKernels.cu
+++ b/gpu-enabler/src/test/resources/testDSCUDAKernels.cu
@@ -440,3 +440,15 @@ mapAll(int count, double *x, double *y, double *result, double *w, int user_D) {
 
 }
 
+extern "C"
+// matrix multiplication simple test kernel
+__global__ void MNKernel(int count, long * Md, long *Nd, long *Pd, int width) {
+ // 2D thread ID
+ int col = blockIdx.x*blockDim.x + threadIdx.x;
+ int row = blockIdx.y*blockDim.y + threadIdx.y;
+ // Pvalue stores the Pd element that is computed by the thread
+ long Pvalue = 0;
+ for (int k=0; k < width; k++)
+    Pvalue += Md[row * width + k] * Nd[k * width + col];
+ Pd[row * width + col] = Pvalue;
+}

--- a/gpu-enabler/src/test/resources/testDSCUDAKernels.ptx
+++ b/gpu-enabler/src/test/resources/testDSCUDAKernels.ptx
@@ -1899,4 +1899,64 @@ BB16_10:
 	ret;
 }
 
+	// .globl	MNKernel
+.visible .entry MNKernel(
+	.param .u32 MNKernel_param_0,
+	.param .u64 MNKernel_param_1,
+	.param .u64 MNKernel_param_2,
+	.param .u64 MNKernel_param_3,
+	.param .u32 MNKernel_param_4
+)
+{
+	.reg .pred 	%p<3>;
+	.reg .b32 	%r<18>;
+	.reg .b64 	%rd<24>;
+
+
+	ld.param.u64 	%rd9, [MNKernel_param_1];
+	ld.param.u64 	%rd10, [MNKernel_param_2];
+	ld.param.u64 	%rd6, [MNKernel_param_3];
+	ld.param.u32 	%r5, [MNKernel_param_4];
+	cvta.to.global.u64 	%rd1, %rd10;
+	cvta.to.global.u64 	%rd2, %rd9;
+	mov.u32 	%r7, %ntid.x;
+	mov.u32 	%r8, %ctaid.x;
+	mov.u32 	%r9, %tid.x;
+	mad.lo.s32 	%r1, %r7, %r8, %r9;
+	mov.u32 	%r10, %ntid.y;
+	mov.u32 	%r11, %ctaid.y;
+	mov.u32 	%r12, %tid.y;
+	mad.lo.s32 	%r13, %r10, %r11, %r12;
+	mul.lo.s32 	%r2, %r13, %r5;
+	mov.u64 	%rd22, 0;
+	mov.u64 	%rd23, %rd22;
+	mov.u32 	%r17, 0;
+	setp.lt.s32	%p1, %r5, 1;
+	@%p1 bra 	BB17_2;
+
+BB17_1:
+	add.s32 	%r14, %r17, %r2;
+	mul.wide.s32 	%rd11, %r14, 8;
+	add.s64 	%rd12, %rd2, %rd11;
+	mad.lo.s32 	%r15, %r17, %r5, %r1;
+	mul.wide.s32 	%rd13, %r15, 8;
+	add.s64 	%rd14, %rd1, %rd13;
+	ld.global.u64 	%rd15, [%rd14];
+	ld.global.u64 	%rd16, [%rd12];
+	mul.lo.s64 	%rd17, %rd15, %rd16;
+	add.s64 	%rd23, %rd17, %rd23;
+	add.s32 	%r17, %r17, 1;
+	setp.lt.s32	%p2, %r17, %r5;
+	mov.u64 	%rd22, %rd23;
+	@%p2 bra 	BB17_1;
+
+BB17_2:
+	cvta.to.global.u64 	%rd18, %rd6;
+	add.s32 	%r16, %r2, %r1;
+	mul.wide.s32 	%rd19, %r16, 8;
+	add.s64 	%rd20, %rd18, %rd19;
+	st.global.u64 	[%rd20], %rd22;
+	ret;
+}
+
 

--- a/gpu-enabler/src/test/scala/com/ibm/gpuenabler/CUDADSFunctionSuite.scala
+++ b/gpu-enabler/src/test/scala/com/ibm/gpuenabler/CUDADSFunctionSuite.scala
@@ -42,6 +42,7 @@ case class PlusMinus(base: Double, deviation: Float)
 case class FloatRange(a: Double, b: Float)
 case class IntDataPoint(x: Array[Int], y: Int)
 case class DataPoint(x: Array[Double], y: Double)
+case class MatrixData(M: Long, N: Long)
 
 class CUDADSFunctionSuite extends FunSuite {
 
@@ -283,6 +284,9 @@ class CUDADSFunctionSuite extends FunSuite {
     import spark.implicits._
     val manager =  GPUSparkEnv.get.cudaManager
     if (manager != null) {
+
+      val dimensions = (size: Long, stage: Int) => (((size + 32 * 8 - 1) / (32 * 8)).toInt, 32, 1, 1, 1, 1);
+      val gpuParams = gpuParameters(dimensions)
       // we only use size/8 GPU threads and run block on a single warp
       val function = DSCUDAFunction(
         "blockXOR",
@@ -290,7 +294,7 @@ class CUDADSFunctionSuite extends FunSuite {
         Array("value"),
         ptxURL,
         None,
-        Some((size: Long, stage: Int) => (((size + 32 * 8 - 1) / (32 * 8)).toInt, 32)))
+        Some(gpuParams))
       
       val n = 10
       
@@ -323,16 +327,17 @@ class CUDADSFunctionSuite extends FunSuite {
     val manager =  GPUSparkEnv.get.cudaManager
     if (manager != null) {
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val function = DSCUDAFunction(
         "sum",
         Array("value"),
         Array("value"),
         ptxURL,
         Some((size: Long) => 2),
-        Some(dimensions), outputSize = Some(1))
+        Some(gpuParams), outputSize = Some(1))
       val n = 30000
 
       try {
@@ -381,16 +386,17 @@ class CUDADSFunctionSuite extends FunSuite {
     val manager =  GPUSparkEnv.get.cudaManager
     if (manager != null) {
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = DSCUDAFunction(
         "sum",
         Array("value"),
         Array("value"),
         ptxURL,
         Some((size: Long) => 2),
-        Some(dimensions), outputSize=Some(1))
+        Some(gpuParams), outputSize=Some(1))
 
       val n = 10
       try {
@@ -418,16 +424,17 @@ class CUDADSFunctionSuite extends FunSuite {
         ptxURL)
 
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = DSCUDAFunction(
         "suml",
         Array("value"),
         Array("value"),
         ptxURL,
         Some((size: Long) => 2),
-        Some(dimensions), outputSize=Some(1))
+        Some(gpuParams), outputSize=Some(1))
 
       val n = 10
       try {
@@ -481,16 +488,17 @@ class CUDADSFunctionSuite extends FunSuite {
         ptxURL)
 
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = DSCUDAFunction(
         "suml",
         Array("value"),
         Array("value"),
         ptxURL,
         Some((size: Long) => 2),
-        Some(dimensions), outputSize=Some(1))
+        Some(gpuParams), outputSize=Some(1))
 
       val n = 100
       try {
@@ -518,16 +526,17 @@ class CUDADSFunctionSuite extends FunSuite {
         ptxURL)
 
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = DSCUDAFunction(
         "suml",
         Array("value"),
         Array("value"),
         ptxURL,
         Some((size: Long) => 2),
-        Some(dimensions), outputSize=Some(1))
+        Some(gpuParams), outputSize=Some(1))
 
       val n: Long = 100000000L
       try {
@@ -557,16 +566,17 @@ class CUDADSFunctionSuite extends FunSuite {
         ptxURL)
 
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = DSCUDAFunction(
         "suml",
         Array("value"),
         Array("value"),
         ptxURL,
         Some((size: Long) => 2),
-        Some(dimensions), outputSize=Some(1))
+        Some(gpuParams), outputSize=Some(1))
 
       val n = 100
       try {
@@ -623,16 +633,17 @@ class CUDADSFunctionSuite extends FunSuite {
         ptxURL)
 
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = DSCUDAFunction(
         "suml",
         Array("value"),
         Array("value"),
         ptxURL,
         Some((size: Long) => 2),
-        Some(dimensions), outputSize=Some(1))
+        Some(gpuParams), outputSize=Some(1))
 
       val n = 100
       try {
@@ -716,16 +727,17 @@ class CUDADSFunctionSuite extends FunSuite {
         Array.tabulate(x.length)(i => x(i) + y(i))
 
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = DSCUDAFunction(
         "intArraySum",
         Array("value"),
         Array("value"),
         ptxURL,
         Some((size: Long) => 2),
-        Some(dimensions), outputSize=Some(1))
+        Some(gpuParams), outputSize=Some(1))
 
       val n = 8
       val dataset = List(Array.range(0, n), Array.range(2*n, 3*n))
@@ -758,9 +770,10 @@ class CUDADSFunctionSuite extends FunSuite {
           Array("value"),
           ptxURL))
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = spark.sparkContext.broadcast(
         DSCUDAFunction(
           "DataPointReduce",
@@ -768,7 +781,7 @@ class CUDADSFunctionSuite extends FunSuite {
           Array("value"),
           ptxURL,
           Some((size: Long) => 2),
-          Some(dimensions), outputSize=Some(1)))
+          Some(gpuParams), outputSize=Some(1)))
       val n = 5
       val w = Array.fill(n)(2.0)
       val dataset = List(DataPoint(Array( 1.0, 2.0, 3.0, 4.0, 5.0), -1),
@@ -819,8 +832,9 @@ class CUDADSFunctionSuite extends FunSuite {
       val threads = 1024
       val blocks = min((N + threads- 1) / threads, 1024)
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (blocks, threads)
+        case 0 => (blocks, threads, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = spark.sparkContext.broadcast(
         DSCUDAFunction(
           "blockReduce",
@@ -828,7 +842,7 @@ class CUDADSFunctionSuite extends FunSuite {
           Array("value"),
           ptxURL,
           Some((size: Long) => 1),
-          Some(dimensions), outputSize=Some(1)))
+          Some(gpuParams), outputSize=Some(1)))
 
       def generateData: Array[DataPoint] = {
         def generatePoint(i: Int): DataPoint = {
@@ -1006,16 +1020,17 @@ test("Run map + map + map + reduce on datasets - Cached multiple partitions", GP
         ptxURL)
 
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = DSCUDAFunction(
         "suml",
         Array("value"),
         Array("value"),
         ptxURL,
         Some((size: Long) => 2),
-        Some(dimensions), outputSize=Some(1))
+        Some(gpuParams), outputSize=Some(1))
 
       val n = 100
       try {
@@ -1045,16 +1060,17 @@ test("Run map + map + map + reduce on datasets - Cached multiple partitions", GP
         ptxURL)
 
       val dimensions = (size: Long, stage: Int) => stage match {
-        case 0 => (64, 256)
-        case 1 => (1, 1)
+        case 0 => (64, 256, 1, 1, 1, 1)
+        case 1 => (1, 1, 1, 1, 1, 1)
       }
+      val gpuParams = gpuParameters(dimensions)
       val reduceFunction = DSCUDAFunction(
         "suml",
         Array("value"),
         Array("value"),
         ptxURL,
         Some((size: Long) => 2),
-        Some(dimensions), outputSize=Some(1))
+        Some(gpuParams), outputSize=Some(1))
 
       val n = 100
       try {
@@ -1072,6 +1088,37 @@ test("Run map + map + map + reduce on datasets - Cached multiple partitions", GP
     }
   }
 
+  test("Run matix multiplication", GPUTest) {
+    val spark = SparkSession.builder().master("local[*]").appName("test").config(conf).getOrCreate()
+    val manager =  GPUSparkEnv.get.cudaManager
+    if (manager != null) {
+      val dimensions = (size: Long, stage: Int) => stage match {
+        case 0 => (1, 3, 1, 3, 1, 1)
+      }
+      val gpuParams = gpuParameters(dimensions)
+      val MRFunction = DSCUDAFunction(
+        "MNKernel",
+        Array("M","N"),
+        Array("value"),
+        ptxURL,
+        Some((size: Long) => 1),
+        Some(gpuParams))
+
+      try {
+        import spark.implicits._
+        val data = spark.range(1, 10, 1, 1).map(x => MatrixData(x, x)).cache()
+        data.count()
+        val output = data.mapExtFunc((x: MatrixData) => x.M, MRFunction, Array(3)).collect()
+        val expected_values : Array[Long] = Array(30,36,42,66,81,96,102,126,150)
+        assert(output.sameElements(expected_values))
+      } finally {
+        spark.stop
+      }
+    } else {
+      info("No CUDA devices, so skipping the test.")
+    }
+  }
+  
 }
 
 


### PR DESCRIPTION
#51  
 # Multi Dimension as input for GPU Grid dimension 
we can pass X,Y,Z co-ordinates for GridSize and BlockSize. 
For Dataset, 

## DSCUDAFunction
### Old Implementation:
```
case class DSCUDAFunction(
                           funcName: String,
                           _inputColumnsOrder: Seq[String] = null,
                           _outputColumnsOrder: Seq[String] = null,
                           resource: Any,
                           stagesCount: Option[Long => Int] = None,
                           dimensions: Option[(Long, Int) => (Int, Int)] = None,
                           outputSize: Option[Long] = None
                           )
```
### New Implementation:
```
/**
  * gpuParameters: This case class is used to describe the GPU Parameters
  * such as dimensions and shared Memory size which is optional.
  * @param dimensions : Dimensions should be Given in the following format
  *                     GridSizeX, BlockSizeX, GridSizeY, BlockSizeY, GridSizeZ, BlockSizeZ.
  * @param sharedMemorySize : SharedMemorySize to be used in Bytes.
  *                           It will be validated with the sharedMemorySize of the GPU.
  */

 // Read as GridSizeX => GridSize in X Dimension

case class gpuParameters (
                        dimensions: (Long, Int) => (Int, Int, Int, Int, Int, Int),
                        sharedMemorySize: Option[Int] = None
                      )

case class DSCUDAFunction(
                           funcName: String,
                           _inputColumnsOrder: Seq[String] = null,
                           _outputColumnsOrder: Seq[String] = null,
                           resource: Any,
                           stagesCount: Option[Long => Int] = None,
                           gpuParams: Option[gpuParameters] = None,
                           outputSize: Option[Long] = None
                         )
```

## Example Comparison: 
### Old Implementation: 
```
val dimensions = (size: Long, stage: Int) => stage match {
      case 0 => (blocks, threads)
    }
val reduceFunction = spark.sparkContext.broadcast(
      DSCUDAFunction(
        "dsblockReduce",
        Array("value"),
        Array("value"),
        ptxURL,
        Some((size: Long) => 1),
        Some(dimensions), outputSize=Some(1)
       )
)
```
### New Implementation: 
```
val dimensions = (size: Long, stage: Int) => stage match {
      case 0 => (blocks, threads, 1, 1, 1, 1)
    }
val gpuParams = gpuParameters(dimensions)
val reduceFunction = spark.sparkContext.broadcast(
      DSCUDAFunction(
        "dsblockReduce",
        Array("value"),
        Array("value"),
        ptxURL,
        Some((size: Long) => 1),
        Some(gpuParams), outputSize=Some(1)
      )
)
```
